### PR TITLE
Refactor methods in Main/Controller to not use exceptions, remove use of Observer and add misc. code quality changes.

### DIFF
--- a/src/main/java/dev/vernonlim/cw2024game/ShieldImage.java
+++ b/src/main/java/dev/vernonlim/cw2024game/ShieldImage.java
@@ -12,7 +12,7 @@ public class ShieldImage extends ImageView {
         this.setLayoutX(xPosition);
         this.setLayoutY(yPosition);
         //this.setImage(new Image(IMAGE_NAME));
-        this.setImage(new Image(getClass().getResource("/dev/vernonlim/cw2024game/images/shield.jpg").toExternalForm()));
+        this.setImage(new Image(getClass().getResource("/dev/vernonlim/cw2024game/" + IMAGE_NAME).toExternalForm()));
         this.setVisible(false);
         this.setFitHeight(SHIELD_SIZE);
         this.setFitWidth(SHIELD_SIZE);

--- a/src/main/java/dev/vernonlim/cw2024game/controller/Controller.java
+++ b/src/main/java/dev/vernonlim/cw2024game/controller/Controller.java
@@ -1,54 +1,47 @@
 package dev.vernonlim.cw2024game.controller;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Observable;
-import java.util.Observer;
+import java.util.Map;
 
+import static java.util.Map.entry;
+
+import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.stage.Stage;
-import dev.vernonlim.cw2024game.LevelParent;
+import dev.vernonlim.cw2024game.levels.*;
 
-public class Controller implements Observer {
+public class Controller {
+    private static final Map<String, Class<? extends LevelParent>> levels = Map.ofEntries(
+            entry("LEVEL_ONE", LevelOne.class),
+            entry("LEVEL_TWO", LevelTwo.class)
+    );
 
-    private static final String LEVEL_ONE_CLASS_NAME = "dev.vernonlim.cw2024game.LevelOne";
     private final Stage stage;
 
     public Controller(Stage stage) {
         this.stage = stage;
     }
 
-    public void launchGame() throws ClassNotFoundException, NoSuchMethodException, SecurityException,
-            InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-
+    public void launchGame() {
         stage.show();
-        goToLevel(LEVEL_ONE_CLASS_NAME);
+        goToLevel("LEVEL_ONE");
     }
 
-    private void goToLevel(String className) throws ClassNotFoundException, NoSuchMethodException, SecurityException,
-            InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        Class<?> myClass = Class.forName(className);
-        Constructor<?> constructor = myClass.getConstructor(double.class, double.class);
-        LevelParent myLevel = (LevelParent) constructor.newInstance(stage.getHeight(), stage.getWidth());
-        myLevel.addObserver(this);
-        Scene scene = myLevel.initializeScene();
-        stage.setScene(scene);
-        myLevel.startGame();
-
-    }
-
-    @Override
-    public void update(Observable arg0, Object arg1) {
+    public void goToLevel(String levelName) {
         try {
-            goToLevel((String) arg1);
-        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | InstantiationException
-                 | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            Class<? extends LevelParent> level = levels.get(levelName);
+            Constructor<?> constructor = level.getConstructor(Controller.class, double.class, double.class);
+            LevelParent myLevel = (LevelParent) constructor.newInstance(this, stage.getHeight(), stage.getWidth());
+            Scene scene = myLevel.initializeScene();
+            stage.setScene(scene);
+            myLevel.startGame();
+        } catch (Exception e) {
             Alert alert = new Alert(AlertType.ERROR);
-            alert.setContentText(e.getClass().toString());
-            alert.show();
+            alert.setContentText("Failed to load Level: " + levelName
+                    + "\nAdditional information: " + e.getMessage());
+            alert.showAndWait().ifPresent(response -> Platform.exit());
         }
     }
-
 }

--- a/src/main/java/dev/vernonlim/cw2024game/controller/Main.java
+++ b/src/main/java/dev/vernonlim/cw2024game/controller/Main.java
@@ -6,20 +6,17 @@ import javafx.application.Application;
 import javafx.stage.Stage;
 
 public class Main extends Application {
-
-    private static final int SCREEN_WIDTH = 1300;
-    private static final int SCREEN_HEIGHT = 750;
+    private static final int SCREEN_WIDTH = 1280;
+    private static final int SCREEN_HEIGHT = 720;
     private static final String TITLE = "Sky Battle";
-    private Controller myController;
 
     @Override
-    public void start(Stage stage) throws ClassNotFoundException, NoSuchMethodException, SecurityException,
-            InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    public void start(Stage stage) {
         stage.setTitle(TITLE);
         stage.setResizable(false);
         stage.setHeight(SCREEN_HEIGHT);
         stage.setWidth(SCREEN_WIDTH);
-        myController = new Controller(stage);
+        Controller myController = new Controller(stage);
         myController.launchGame();
     }
 

--- a/src/main/java/dev/vernonlim/cw2024game/levels/LevelOne.java
+++ b/src/main/java/dev/vernonlim/cw2024game/levels/LevelOne.java
@@ -7,7 +7,7 @@ import dev.vernonlim.cw2024game.controller.Controller;
 
 public class LevelOne extends LevelParent {
     private static final String BACKGROUND_IMAGE_NAME = "/dev/vernonlim/cw2024game/images/background1.jpg";
-    private static final String NEXT_LEVEL = "LEVEL_TWO210329138";
+    private static final String NEXT_LEVEL = "LEVEL_TWO";
     private static final int TOTAL_ENEMIES = 5;
     private static final int KILLS_TO_ADVANCE = 10;
     private static final double ENEMY_SPAWN_PROBABILITY = .20;

--- a/src/main/java/dev/vernonlim/cw2024game/levels/LevelOne.java
+++ b/src/main/java/dev/vernonlim/cw2024game/levels/LevelOne.java
@@ -1,24 +1,29 @@
-package dev.vernonlim.cw2024game;
+package dev.vernonlim.cw2024game.levels;
+
+import dev.vernonlim.cw2024game.ActiveActorDestructible;
+import dev.vernonlim.cw2024game.EnemyPlane;
+import dev.vernonlim.cw2024game.LevelView;
+import dev.vernonlim.cw2024game.controller.Controller;
 
 public class LevelOne extends LevelParent {
-
     private static final String BACKGROUND_IMAGE_NAME = "/dev/vernonlim/cw2024game/images/background1.jpg";
-    private static final String NEXT_LEVEL = "dev.vernonlim.cw2024game.LevelTwo";
+    private static final String NEXT_LEVEL = "LEVEL_TWO210329138";
     private static final int TOTAL_ENEMIES = 5;
     private static final int KILLS_TO_ADVANCE = 10;
     private static final double ENEMY_SPAWN_PROBABILITY = .20;
     private static final int PLAYER_INITIAL_HEALTH = 5;
 
-    public LevelOne(double screenHeight, double screenWidth) {
-        super(BACKGROUND_IMAGE_NAME, screenHeight, screenWidth, PLAYER_INITIAL_HEALTH);
+    public LevelOne(Controller controller, double screenHeight, double screenWidth) {
+        super(controller, BACKGROUND_IMAGE_NAME, screenHeight, screenWidth, PLAYER_INITIAL_HEALTH);
     }
 
     @Override
     protected void checkIfGameOver() {
         if (userIsDestroyed()) {
             loseGame();
-        } else if (userHasReachedKillTarget())
+        } else if (userHasReachedKillTarget()) {
             goToNextLevel(NEXT_LEVEL);
+        }
     }
 
     @Override

--- a/src/main/java/dev/vernonlim/cw2024game/levels/LevelParent.java
+++ b/src/main/java/dev/vernonlim/cw2024game/levels/LevelParent.java
@@ -1,9 +1,15 @@
-package dev.vernonlim.cw2024game;
+package dev.vernonlim.cw2024game.levels;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
+import dev.vernonlim.cw2024game.ActiveActorDestructible;
+import dev.vernonlim.cw2024game.FighterPlane;
+import dev.vernonlim.cw2024game.LevelView;
+import dev.vernonlim.cw2024game.UserPlane;
+import dev.vernonlim.cw2024game.controller.Controller;
 import javafx.animation.*;
+import javafx.application.Platform;
 import javafx.event.EventHandler;
 import javafx.scene.Group;
 import javafx.scene.Scene;
@@ -11,8 +17,7 @@ import javafx.scene.image.*;
 import javafx.scene.input.*;
 import javafx.util.Duration;
 
-public abstract class LevelParent extends Observable {
-
+public abstract class LevelParent {
     private static final double SCREEN_HEIGHT_ADJUSTMENT = 150;
     private static final int MILLISECOND_DELAY = 50;
     private final double screenHeight;
@@ -33,7 +38,9 @@ public abstract class LevelParent extends Observable {
     private int currentNumberOfEnemies;
     private final LevelView levelView;
 
-    public LevelParent(String backgroundImageName, double screenHeight, double screenWidth, int playerInitialHealth) {
+    private final Controller controller;
+
+    public LevelParent(Controller controller, String backgroundImageName, double screenHeight, double screenWidth, int playerInitialHealth) {
         this.root = new Group();
         this.scene = new Scene(root, screenWidth, screenHeight);
         this.timeline = new Timeline();
@@ -51,6 +58,8 @@ public abstract class LevelParent extends Observable {
         this.currentNumberOfEnemies = 0;
         initializeTimeline();
         friendlyUnits.add(user);
+
+        this.controller = controller;
     }
 
     protected abstract void initializeFriendlyUnits();
@@ -74,8 +83,10 @@ public abstract class LevelParent extends Observable {
     }
 
     public void goToNextLevel(String levelName) {
-        setChanged();
-        notifyObservers(levelName);
+        timeline.pause();
+        Platform.runLater(() -> {
+            controller.goToLevel(levelName);
+        });
     }
 
     private void updateScene() {

--- a/src/main/java/dev/vernonlim/cw2024game/levels/LevelTwo.java
+++ b/src/main/java/dev/vernonlim/cw2024game/levels/LevelTwo.java
@@ -1,14 +1,18 @@
-package dev.vernonlim.cw2024game;
+package dev.vernonlim.cw2024game.levels;
+
+import dev.vernonlim.cw2024game.Boss;
+import dev.vernonlim.cw2024game.LevelView;
+import dev.vernonlim.cw2024game.LevelViewLevelTwo;
+import dev.vernonlim.cw2024game.controller.Controller;
 
 public class LevelTwo extends LevelParent {
-
     private static final String BACKGROUND_IMAGE_NAME = "/dev/vernonlim/cw2024game/images/background2.jpg";
     private static final int PLAYER_INITIAL_HEALTH = 5;
     private final Boss boss;
     private LevelViewLevelTwo levelView;
 
-    public LevelTwo(double screenHeight, double screenWidth) {
-        super(BACKGROUND_IMAGE_NAME, screenHeight, screenWidth, PLAYER_INITIAL_HEALTH);
+    public LevelTwo(Controller controller, double screenHeight, double screenWidth) {
+        super(controller, BACKGROUND_IMAGE_NAME, screenHeight, screenWidth, PLAYER_INITIAL_HEALTH);
         boss = new Boss();
     }
 
@@ -38,5 +42,4 @@ public class LevelTwo extends LevelParent {
         levelView = new LevelViewLevelTwo(getRoot(), PLAYER_INITIAL_HEALTH);
         return levelView;
     }
-
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,4 +5,5 @@ module dev.vernonlim.cw2024game {
 
     opens dev.vernonlim.cw2024game to javafx.fxml;
     exports dev.vernonlim.cw2024game.controller;
+    opens dev.vernonlim.cw2024game.levels to javafx.fxml;
 }


### PR DESCRIPTION
Unfortunately, splitting all 3 changes above into multiple PRs (or commits) would be a lot more trouble than it would be worth.

The methods in Controller and Main, such as start(Stage stage) had 7 different exceptions tied to them, all related to the level loading system utilizing reflection. Instead of propagating each exception up to every function in the call stack, all possible exceptions are now handled in the `goToLevel` method, as an error window that pauses program execution and then quits it upon close.
    
Levels are also now stored as a `Map<String, Class>`, along with hardcoding the classes at compile time. This allows for compile-time checks that the levels exist, while still using String names for levels.
    
`Observer` has been deprecated since Java 9, and while there is a modern equivalent in the form of `Listener`, I decided to replace it with simply passing the controller instance to the `LevelParent`. The reason for this is that the Observer pattern is most useful for informing many different parts of the program of an event at once, after which they can respond asynchronously.

In the program, the only way in which this is used is informing a single section of the code to load a level, during which the program should in fact *not* be running asynchronously in the background. As such, passing the controller instance works as a much simpler solution. During this process, I also fixed the loading of `LevelTwo`.

