### PR TITLE
Refactor projectile spawning to be callback-based

### DIFF
--- a/src/main/java/dev/vernonlim/cw2024game/elements/ProjectileListener.java
+++ b/src/main/java/dev/vernonlim/cw2024game/elements/ProjectileListener.java
@@ -1,0 +1,7 @@
+package dev.vernonlim.cw2024game.elements;
+
+import dev.vernonlim.cw2024game.elements.actors.Projectile;
+
+public interface ProjectileListener {
+    public void onFire(Projectile projectile);
+}

--- a/src/main/java/dev/vernonlim/cw2024game/elements/actors/Boss.java
+++ b/src/main/java/dev/vernonlim/cw2024game/elements/actors/Boss.java
@@ -1,7 +1,7 @@
 package dev.vernonlim.cw2024game.elements.actors;
 
 import dev.vernonlim.cw2024game.Main;
-import dev.vernonlim.cw2024game.overlays.LevelView;
+import dev.vernonlim.cw2024game.elements.ProjectileListener;
 import javafx.scene.layout.Pane;
 
 import java.util.*;
@@ -23,15 +23,14 @@ public class Boss extends FighterPlane {
     private int indexOfCurrentMove;
     private double lastShieldActivation;
     private double timeWithShieldActivated;
-    private LevelView levelView;
 
     private ShieldImage shieldImage;
 
     private double upperBound;
     private double lowerBound;
 
-    public Boss(Pane root, LevelView levelView) {
-        super(root, IMAGE_NAME, IMAGE_HEIGHT, HEALTH);
+    public Boss(Pane root, ProjectileListener projectileListener) {
+        super(root, projectileListener, IMAGE_NAME, IMAGE_HEIGHT, HEALTH);
 
         setXFromRight(5.0f);
         setY(Main.SCREEN_HEIGHT / 2.0f);
@@ -48,8 +47,6 @@ public class Boss extends FighterPlane {
         initializeMovePattern();
 
         this.shieldImage = new ShieldImage(root);
-
-        this.levelView = levelView;
     }
 
     @Override
@@ -63,13 +60,15 @@ public class Boss extends FighterPlane {
     public void updateActor(double deltaTime, double currentTime) {
         updatePosition(deltaTime);
         updateShield(deltaTime, currentTime);
+
+        if (bossFiresInCurrentFrame(currentTime)) {
+            fireProjectile();
+        }
     }
 
     @Override
-    public ActiveActorDestructible fireProjectile(double currentTime) {
-        return bossFiresInCurrentFrame(currentTime)
-                ? new BossProjectile(root, getX() - getHalfWidth(), getY() + PROJECTILE_Y_OFFSET)
-                : null;
+    public Projectile createProjectile() {
+        return new BossProjectile(root, getX() - getHalfWidth(), getY() + PROJECTILE_Y_OFFSET);
     }
 
     @Override

--- a/src/main/java/dev/vernonlim/cw2024game/elements/actors/EnemyPlane.java
+++ b/src/main/java/dev/vernonlim/cw2024game/elements/actors/EnemyPlane.java
@@ -1,5 +1,6 @@
 package dev.vernonlim.cw2024game.elements.actors;
 
+import dev.vernonlim.cw2024game.elements.ProjectileListener;
 import javafx.scene.layout.Pane;
 
 public class EnemyPlane extends FighterPlane {
@@ -10,8 +11,8 @@ public class EnemyPlane extends FighterPlane {
     private static final double FIRE_RATE = 0.01;
     private static final double PROJECTILE_Y_OFFSET = 7.0f;
 
-    public EnemyPlane(Pane root, double initialXPos, double initialYPos) {
-        super(root, IMAGE_NAME, IMAGE_HEIGHT, INITIAL_HEALTH);
+    public EnemyPlane(Pane root, ProjectileListener projectileListener, double initialXPos, double initialYPos) {
+        super(root, projectileListener, IMAGE_NAME, IMAGE_HEIGHT, INITIAL_HEALTH);
 
         setPosition(initialXPos, initialYPos);
     }
@@ -22,22 +23,22 @@ public class EnemyPlane extends FighterPlane {
     }
 
     @Override
-    public ActiveActorDestructible fireProjectile(double currentTime) {
+    public void updateActor(double deltaTime, double currentTime) {
+        updatePosition(deltaTime);
+
         if ((currentTime - lastFireTime) > 50.0f) {
             lastFireTime = currentTime;
 
             boolean shouldFire = Math.random() < FIRE_RATE;
 
             if (shouldFire) {
-                return new EnemyProjectile(root, getX() - getHalfWidth(), getY() + PROJECTILE_Y_OFFSET);
+                fireProjectile();
             }
         }
-
-        return null;
     }
 
     @Override
-    public void updateActor(double deltaTime, double currentTime) {
-        updatePosition(deltaTime);
+    public Projectile createProjectile() {
+        return new EnemyProjectile(root, getX() - getHalfWidth(), getY() + PROJECTILE_Y_OFFSET);
     }
 }

--- a/src/main/java/dev/vernonlim/cw2024game/elements/actors/FighterPlane.java
+++ b/src/main/java/dev/vernonlim/cw2024game/elements/actors/FighterPlane.java
@@ -1,19 +1,28 @@
 package dev.vernonlim.cw2024game.elements.actors;
 
+import dev.vernonlim.cw2024game.elements.ProjectileListener;
 import javafx.scene.layout.Pane;
 
 public abstract class FighterPlane extends ActiveActorDestructible {
     private int health;
     protected double lastFireTime;
 
-    public FighterPlane(Pane root, String imageName, int imageHeight, int health) {
+    private ProjectileListener projectileListener;
+
+    public FighterPlane(Pane root, ProjectileListener projectileListener, String imageName, int imageHeight, int health) {
         super(root, imageName, imageHeight);
         this.health = health;
+
+        this.projectileListener = projectileListener;
 
         this.lastFireTime = -99999;
     }
 
-    public abstract ActiveActorDestructible fireProjectile(double currentTime);
+    public void fireProjectile() {
+        projectileListener.onFire(createProjectile());
+    }
+
+    public abstract Projectile createProjectile();
 
     @Override
     public void takeDamage() {

--- a/src/main/java/dev/vernonlim/cw2024game/elements/actors/UserPlane.java
+++ b/src/main/java/dev/vernonlim/cw2024game/elements/actors/UserPlane.java
@@ -1,5 +1,6 @@
 package dev.vernonlim.cw2024game.elements.actors;
 
+import dev.vernonlim.cw2024game.elements.ProjectileListener;
 import dev.vernonlim.cw2024game.input.Input;
 import dev.vernonlim.cw2024game.Main;
 import javafx.scene.layout.Pane;
@@ -24,8 +25,8 @@ public class UserPlane extends FighterPlane {
     private double leftBound;
     private double rightBound;
 
-    public UserPlane(Pane root, int initialHealth, Input input) {
-        super(root, IMAGE_NAME, IMAGE_HEIGHT, initialHealth);
+    public UserPlane(Pane root, ProjectileListener projectileListener, Input input, int initialHealth) {
+        super(root, projectileListener, IMAGE_NAME, IMAGE_HEIGHT, initialHealth);
 
         setXFromLeft(5);
         setY(Main.SCREEN_HEIGHT / 2.0f);
@@ -97,18 +98,18 @@ public class UserPlane extends FighterPlane {
             fireRate *= 2.0;
         }
 
+        if (input.isFirePressed() && (currentTime - lastFireTime) > (1000.0f / fireRate)) {
+            lastFireTime = currentTime;
+
+            fireProjectile();
+        }
+
         updatePosition(deltaTime);
     }
 
     @Override
-    public ActiveActorDestructible fireProjectile(double currentTime) {
-        if (input.isFirePressed() && (currentTime - lastFireTime) > (1000.0f / fireRate)) {
-            lastFireTime = currentTime;
-
-            return new UserProjectile(root, getX() + getHalfWidth(), getY() + PROJECTILE_Y_OFFSET);
-        }
-
-        return null;
+    public Projectile createProjectile() {
+        return new UserProjectile(root, getX() + getHalfWidth(), getY() + PROJECTILE_Y_OFFSET);
     }
 
     public int getNumberOfKills() {

--- a/src/main/java/dev/vernonlim/cw2024game/overlays/Overlay.java
+++ b/src/main/java/dev/vernonlim/cw2024game/overlays/Overlay.java
@@ -6,7 +6,7 @@ import dev.vernonlim.cw2024game.elements.HeartDisplay;
 import dev.vernonlim.cw2024game.elements.WinImage;
 import javafx.scene.layout.Pane;
 
-public class LevelView {
+public class Overlay {
     private static final double HEART_DISPLAY_X_POSITION = 5;
     private static final double HEART_DISPLAY_Y_POSITION = 25;
     private static final int WIN_IMAGE_X_POSITION = 355;
@@ -18,7 +18,7 @@ public class LevelView {
     private final Element gameOverImage;
     private final HeartDisplay heartDisplay;
 
-    public LevelView(Pane root, int heartsToDisplay) {
+    public Overlay(Pane root, int heartsToDisplay) {
         this.root = root;
         this.heartDisplay = new HeartDisplay(root, HEART_DISPLAY_X_POSITION, HEART_DISPLAY_Y_POSITION, heartsToDisplay);
         this.winImage = new WinImage(root, WIN_IMAGE_X_POSITION, WIN_IMAGE_Y_POSITION);

--- a/src/main/java/dev/vernonlim/cw2024game/screens/LevelOne.java
+++ b/src/main/java/dev/vernonlim/cw2024game/screens/LevelOne.java
@@ -4,7 +4,7 @@ import dev.vernonlim.cw2024game.Main;
 import dev.vernonlim.cw2024game.elements.actors.ActiveActorDestructible;
 import dev.vernonlim.cw2024game.elements.actors.EnemyPlane;
 import dev.vernonlim.cw2024game.Controller;
-import dev.vernonlim.cw2024game.overlays.LevelView;
+import dev.vernonlim.cw2024game.overlays.Overlay;
 
 public class LevelOne extends LevelParent {
     private static final String BACKGROUND_IMAGE_NAME = "/images/background1.jpg";
@@ -41,7 +41,7 @@ public class LevelOne extends LevelParent {
             for (int i = 0; i < TOTAL_ENEMIES - currentNumberOfEnemies; i++) {
                 if (Math.random() < ENEMY_SPAWN_PROBABILITY) {
                     double newEnemyInitialYPosition = Math.random() * getEnemyMaximumYPosition() + 54;
-                    ActiveActorDestructible newEnemy = new EnemyPlane(getRoot(), Main.SCREEN_WIDTH, newEnemyInitialYPosition);
+                    ActiveActorDestructible newEnemy = new EnemyPlane(getRoot(), enemyProjectileListener, Main.SCREEN_WIDTH, newEnemyInitialYPosition);
                     addEnemyUnit(newEnemy);
                 }
             }
@@ -49,8 +49,8 @@ public class LevelOne extends LevelParent {
     }
 
     @Override
-    protected LevelView instantiateLevelView() {
-        return new LevelView(getRoot(), PLAYER_INITIAL_HEALTH);
+    protected Overlay instantiateLevelView() {
+        return new Overlay(getRoot(), PLAYER_INITIAL_HEALTH);
     }
 
     private boolean userHasReachedKillTarget() {

--- a/src/main/java/dev/vernonlim/cw2024game/screens/LevelTwo.java
+++ b/src/main/java/dev/vernonlim/cw2024game/screens/LevelTwo.java
@@ -2,19 +2,17 @@ package dev.vernonlim.cw2024game.screens;
 
 import dev.vernonlim.cw2024game.elements.actors.Boss;
 import dev.vernonlim.cw2024game.Controller;
-import dev.vernonlim.cw2024game.overlays.LevelView;
-import javafx.scene.layout.Pane;
+import dev.vernonlim.cw2024game.overlays.Overlay;
 
 public class LevelTwo extends LevelParent {
     private static final String BACKGROUND_IMAGE_NAME = "/images/background2.jpg";
     private static final int PLAYER_INITIAL_HEALTH = 5;
     private final Boss boss;
-    private LevelView levelView;
 
     public LevelTwo(Controller controller) {
         super(controller, BACKGROUND_IMAGE_NAME, PLAYER_INITIAL_HEALTH);
 
-        boss = new Boss(getRoot(), levelView);
+        boss = new Boss(getRoot(), enemyProjectileListener);
     }
 
     @Override
@@ -39,8 +37,7 @@ public class LevelTwo extends LevelParent {
     }
 
     @Override
-    protected LevelView instantiateLevelView() {
-        levelView = new LevelView(getRoot(), PLAYER_INITIAL_HEALTH);
-        return levelView;
+    protected Overlay instantiateLevelView() {
+        return new Overlay(getRoot(), PLAYER_INITIAL_HEALTH);
     }
 }


### PR DESCRIPTION
This creates a `ProjectileListener` class which all instances of `FighterPlane` get an instance of. It has an `onFire(Projectile projectile)` method which determines what is done with the projectile it's passed. `fireProjectile()` is now a method that calls `onFire` with `createProjectile()`, with the latter being what's overridden by subclasses.

Now, actors determine when they fire projectiles, based on their state during the update loop.